### PR TITLE
Add curl in Docker image to facilitate Docker Swarm health checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,6 @@ RUN pytest
 RUN echo "tests completed" >> /test_results.log
 
 FROM finalimage AS production
-COPY --from=curlimages/curl:latest /usr/bin/curl /usr/bin/curl
+COPY --from=shakefu/curl-static:latest /usr/local/bin/curl /usr/local/bin/curl
 COPY --from=test /test_results.log /test_results.log
 ENTRYPOINT ["/server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,5 +49,6 @@ RUN pytest
 RUN echo "tests completed" >> /test_results.log
 
 FROM finalimage AS production
+COPY --from curlimages/curl:latest /usr/bin/curl /usr/bin/curl
 COPY --from=test /test_results.log /test_results.log
 ENTRYPOINT ["/server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,6 @@ RUN pytest
 RUN echo "tests completed" >> /test_results.log
 
 FROM finalimage AS production
-COPY --from curlimages/curl:latest /usr/bin/curl /usr/bin/curl
+COPY --from=curlimages/curl:latest /usr/bin/curl /usr/bin/curl
 COPY --from=test /test_results.log /test_results.log
 ENTRYPOINT ["/server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ FROM finalimage AS dev
 CMD [ "/bin/bash" ]
 
 # Run tests in a Python image based on ubuntu.
-FROM fnndsc/ubuntu-python3:ubuntu20.04-python3.8.10 as test
+FROM python:3.11.15-trixie AS test
 COPY --from=finalimage /config.txt /
 COPY --from=finalimage /server /
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - source: API-key
         target: config.txt
 
-healthcheck:
+    healthcheck:
       test: ["CMD", "curl", "http://0.0.0.0:6789/status"]
       interval: 60s
       timeout: 2s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,14 @@ services:
         target: /privateKey.key
       - source: API-key
         target: config.txt
+
+healthcheck:
+      test: ["CMD", "curl", "http://0.0.0.0:6789/status"]
+      interval: 60s
+      timeout: 2s
+      retries: 2
+      start_period: 20s
+      
 secrets:
   key:
     file: D:\your\own\directory\certs\customkey.key # change this if you want to use https

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -13,7 +13,7 @@ SERVER_NAME = "TestServer"
 
 # Start the server, wait for one second so that it can properly boot.
 subprocess.Popen(['/server', PORT, 'h', '0', 'a', API_KEY, 't', str(NUMBER_OF_THREADS), 'n', SERVER_NAME])
-time.sleep(1)
+time.sleep(10)
 
 
 def test_no_locks():

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -13,7 +13,7 @@ SERVER_NAME = "TestServer"
 
 # Start the server, wait for one second so that it can properly boot.
 subprocess.Popen(['/server', PORT, 'h', '0', 'a', API_KEY, 't', str(NUMBER_OF_THREADS), 'n', SERVER_NAME])
-time.sleep(10)
+time.sleep(1)
 
 
 def test_no_locks():


### PR DESCRIPTION
I want to use [health checks](https://docs.docker.com/reference/compose-file/services/#healthcheck) in my Docker Swarm set-up. Unfortunately, Docker Swarm runs the health check from the container itself - so (in this case) curl needs to be available in the Docker image. 

Also bump the used docker image for testing (Python) because:
```log
> [test 7/9] RUN /server:
0.164 /server: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.32' not found (required by /server)
0.164 /server: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by /server)
0.164 /server: /lib/x86_64-linux-gnu/libstdc++.so.6: version `CXXABI_1.3.13' not found (required by /server)
0.164 /server: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /server)
0.165 /server: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /server)
0.165 /server: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /server)
0.165 /server: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /server)
```